### PR TITLE
Fixes plugin list with version-constrained plugins

### DIFF
--- a/testdata/plugin-list
+++ b/testdata/plugin-list
@@ -1,6 +1,8 @@
-1562184653,,ui,info,vagrant-disksize (0.1.3%!(VAGRANT_COMMA) global)
-1562184653,,plugin-name,vagrant-disksize
-1562184653,vagrant-disksize,plugin-version,0.1.3%!(VAGRANT_COMMA) global
-1562184653,,ui,info,vagrant-ip-show (0.0.4%!(VAGRANT_COMMA) global)
-1562184653,,plugin-name,vagrant-ip-show
-1562184653,vagrant-ip-show,plugin-version,0.0.4%!(VAGRANT_COMMA) global
+1562938270,,ui,info,vagrant-disksize (0.1.3%!(VAGRANT_COMMA) global)
+1562938270,,plugin-name,vagrant-disksize
+1562938270,vagrant-disksize,plugin-version,0.1.3%!(VAGRANT_COMMA) global
+1562938270,,ui,info,  - Version Constraint: 0.1.3
+1562938270,vagrant-disksize,plugin-version-constraint,0.1.3
+1562938270,,ui,info,vagrant-ip-show (0.0.4%!(VAGRANT_COMMA) global)
+1562938270,,plugin-name,vagrant-ip-show
+1562938270,vagrant-ip-show,plugin-version,0.0.4%!(VAGRANT_COMMA) global

--- a/wrapper.go
+++ b/wrapper.go
@@ -153,17 +153,20 @@ func (w wrapper) PluginList() (plugins []Plugin, err error) {
 	}
 	pluginMetadataExtractor := regexp.MustCompile(`^([\w-]+)\s\((.*)%!\(VAGRANT_COMMA\)\s([a-z]+)\)$`)
 	for _, entry := range pluginInfo {
-		if entry.mType == "ui" { // "ui" type contains combined name/version data
+		if entry.mType == "ui" { // "ui" type may contain combined name/version data
 			combinedData := entry.data[1]
 			if strings.Contains(combinedData, "No plugins installed") {
 				break
 			}
-			matches := pluginMetadataExtractor.FindAllStringSubmatch(combinedData, -1)[0][1:]
-			plugins = append(plugins, Plugin{
-				Name:     matches[0],
-				Version:  matches[1],
-				Location: matches[2],
-			})
+
+			if ms := pluginMetadataExtractor.FindAllStringSubmatch(combinedData, -1); ms != nil {
+				matches := ms[0][1:] // lens into captures
+				plugins = append(plugins, Plugin{
+					Name:     matches[0],
+					Version:  matches[1],
+					Location: matches[2],
+				})
+			}
 		}
 	}
 	return


### PR DESCRIPTION
if a plugin is installed with a specific version, then that version
constraint will pop up in a "ui" element. this change guards against
trying to extract the matches when the regex fails and returns nil.

a better implementation would probably NOT use the "ui" type and
perform a more involved parsing of the individual name and version
fields.