### PR TITLE
improve SSH function

### DIFF
--- a/wrapper.go
+++ b/wrapper.go
@@ -13,14 +13,14 @@ import (
 
 const binary = "vagrant"
 
-// Vagrant defines the interface for executing Vagrant commands
+// Vagrant defines the interface for executing Vagrant commands.
 type Vagrant interface {
 	Up() error
 	Halt() error
 	Destroy() error
 	Status() ([]MachineStatus, error)
 	Version() (string, error)
-	SSH(string) (string, error)
+	SSH(string, string) (string, error)
 
 	PluginList() ([]Plugin, error)
 	PluginInstall(Plugin) error
@@ -136,8 +136,14 @@ func (w wrapper) Version() (version string, err error) {
 }
 
 // SSH executes a command on a Vagrant machine via SSH and returns the stdout/stderr output.
-func (w wrapper) SSH(command string) (string, error) {
-	out, err := w.exec("ssh", "--no-tty", "--command", command)
+// You can use an empty string as the nameOrID if you only have one VM defined in your Vagrantfile.
+func (w wrapper) SSH(nameOrID, command string) (string, error) {
+	cmdArgs := []string{"ssh", "--no-tty", "--command", command}
+	if len(nameOrID) > 0 {
+		cmdArgs = append(cmdArgs, nameOrID)
+	}
+
+	out, err := w.exec(cmdArgs...)
 	return string(out), err
 }
 

--- a/wrapper_test.go
+++ b/wrapper_test.go
@@ -193,7 +193,16 @@ func TestSSH(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		w := mockSSH([]byte("command output"), nil)
 
-		output, err := w.SSH(sshCmd)
+		output, err := w.SSH("", sshCmd)
+		assert.NoError(t, err)
+		assert.Equal(t, "command output", output)
+	})
+
+	t.Run("specific_name", func(t *testing.T) {
+		mockSSH := mockedWrapperFn([]string{"ssh", "--no-tty", "--command", sshCmd, "my-target"})
+		wrapper := mockSSH([]byte("command output"), nil)
+
+		output, err := wrapper.SSH("my-target", sshCmd)
 		assert.NoError(t, err)
 		assert.Equal(t, "command output", output)
 	})
@@ -201,7 +210,7 @@ func TestSSH(t *testing.T) {
 	t.Run("error", func(t *testing.T) {
 		w := mockSSH(nil, errors.New("runner error"))
 
-		_, err := w.SSH(sshCmd)
+		_, err := w.SSH("", sshCmd)
 		assert.Error(t, err)
 	})
 }


### PR DESCRIPTION
the previous implementation assumed on a single VM in the Vagrantfile
and this would produce and error when that was not the case. this change
allows users to specifically target vms when there are multiple defined.